### PR TITLE
Feature/spell controllers

### DIFF
--- a/griffindor-backend/src/main/java/com/devathon/griffindor_backend/controllers/SpellController.java
+++ b/griffindor-backend/src/main/java/com/devathon/griffindor_backend/controllers/SpellController.java
@@ -1,0 +1,32 @@
+package com.devathon.griffindor_backend.controllers;
+
+import com.devathon.griffindor_backend.dtos.SpellResponseDto;
+import com.devathon.griffindor_backend.models.Spell;
+import com.devathon.griffindor_backend.services.SpellService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Controller
+@RequestMapping("spells")
+public class SpellController {
+
+    private final SpellService spellService;
+
+    public SpellController(SpellService spellService) {
+        this.spellService = spellService;
+    }
+
+    @GetMapping("")
+    public ResponseEntity<List<SpellResponseDto>> getAllSpell(){
+        // Mappear cada item de la lista a dto
+        List<SpellResponseDto> spells = spellService.getAll().stream()
+                .map(SpellResponseDto::new)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(spells);
+    }
+}

--- a/griffindor-backend/src/main/java/com/devathon/griffindor_backend/controllers/SpellController.java
+++ b/griffindor-backend/src/main/java/com/devathon/griffindor_backend/controllers/SpellController.java
@@ -5,6 +5,7 @@ import com.devathon.griffindor_backend.models.Spell;
 import com.devathon.griffindor_backend.services.SpellService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -13,6 +14,7 @@ import java.util.stream.Collectors;
 
 @Controller
 @RequestMapping("spells")
+@CrossOrigin("*") // TODO: Verify CORS configuration
 public class SpellController {
 
     private final SpellService spellService;

--- a/griffindor-backend/src/main/java/com/devathon/griffindor_backend/controllers/SpellController.java
+++ b/griffindor-backend/src/main/java/com/devathon/griffindor_backend/controllers/SpellController.java
@@ -23,7 +23,7 @@ public class SpellController {
 
     @GetMapping("")
     public ResponseEntity<List<SpellResponseDto>> getAllSpell(){
-        // Mappear cada item de la lista a dto
+        // Entities to dtos
         List<SpellResponseDto> spells = spellService.getAll().stream()
                 .map(SpellResponseDto::new)
                 .collect(Collectors.toList());

--- a/griffindor-backend/src/main/java/com/devathon/griffindor_backend/dtos/SpellResponseDto.java
+++ b/griffindor-backend/src/main/java/com/devathon/griffindor_backend/dtos/SpellResponseDto.java
@@ -1,0 +1,19 @@
+package com.devathon.griffindor_backend.dtos;
+
+import com.devathon.griffindor_backend.models.Spell;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+public class SpellResponseDto {
+        private UUID id;
+        private String name;
+        private SpellShortDto counterSpell;
+
+        public SpellResponseDto(Spell spell) {
+            this.id = spell.getId();
+            this.name = spell.getName();
+            this.counterSpell = (spell.getCounterSpell() != null) ? new SpellShortDto(spell.getCounterSpell()) : null;
+        }
+}

--- a/griffindor-backend/src/main/java/com/devathon/griffindor_backend/dtos/SpellShortDto.java
+++ b/griffindor-backend/src/main/java/com/devathon/griffindor_backend/dtos/SpellShortDto.java
@@ -1,0 +1,17 @@
+package com.devathon.griffindor_backend.dtos;
+
+import com.devathon.griffindor_backend.models.Spell;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+public class SpellShortDto {
+    private UUID id;
+    private String name;
+
+    public SpellShortDto(Spell spell) {
+        this.id = spell.getId();
+        this.name = spell.getName();
+    }
+}

--- a/griffindor-backend/src/main/java/com/devathon/griffindor_backend/services/Impl/SpellServiceImpl.java
+++ b/griffindor-backend/src/main/java/com/devathon/griffindor_backend/services/Impl/SpellServiceImpl.java
@@ -16,7 +16,7 @@ public class SpellServiceImpl implements SpellService {
     @Autowired
     SpellRepository spellRepository;
 
-    // Obtener hechizos
+    // Get all spells
     @Override
     public List<Spell> getAll() {
         return spellRepository.findAll();
@@ -24,21 +24,18 @@ public class SpellServiceImpl implements SpellService {
 
     @Override
     public DuelResultDto resolveDuel(UUID spellUser1, UUID spellUser2) {
-        // Obtiene los hechizos por su id. Si no se encuentran, lanza una excepción (orElseThrow)
+
         Spell spell1 = spellRepository.findById(spellUser1).orElseThrow();
         Spell spell2 = spellRepository.findById(spellUser2).orElseThrow();
 
-        // Si son iguales, se declara empate
         if (spell1.equals(spell2)) {
             return new DuelResultDto(null, null, true);
         }
 
-        // Si spell1 tiene un contra-hechizo y ese contra-hechizo es spell2, entonces spell2 gana el duelo
         if (spell1.getCounterSpell() != null && spell1.getCounterSpell().equals(spell2)) {
             return new DuelResultDto(spell2, spell1, false);
         }
 
-        // Si ninguna de las condiciones anteriores se cumple, spell1 gana el duelo
         return new DuelResultDto(spell1, spell2, false);
     }
 


### PR DESCRIPTION
- Controlador de hechizos (SpellController) añadido. Comunicación HTTP.
- Habilitación de CORS para todos los orígenes. **En el futuro, habilitar CORS solo para los orígenes permitidos**.

Probar en el navegador o herramientas como postman.
Ruta: localhost[PORT]/spells        ej: http://localhost:8080/spells