### PR TITLE
feat: jwt with cookies

### DIFF
--- a/griffindor-backend/.env.example
+++ b/griffindor-backend/.env.example
@@ -10,3 +10,5 @@ DB_PASS=                  # Contraseña para el usuario de la base de datos dent
 DB_HOST=                  # Dirección del host donde se encuentra la base de datos (por lo general, el nombre del servicio de Docker o localhost)
 DB_PORT=                  # Puerto de la base de datos (por lo general, el puerto 3306 para MySQL)
 DB_ROOT_PASSWORD=         # Contraseña para el usuario root de la base de datos dentro del contenedor Docker
+
+JWT_SECRET=               # Clave secreta para JWT

--- a/griffindor-backend/src/main/java/com/devathon/griffindor_backend/controllers/GameSessionController.java
+++ b/griffindor-backend/src/main/java/com/devathon/griffindor_backend/controllers/GameSessionController.java
@@ -67,7 +67,7 @@ public class GameSessionController {
                 String oldSessionId = jwt.validateAndGetUser(token);
 
                 if (playerService.existsBySessionId(oldSessionId)) {
-                    String newToken = jwt.generateToken(sessionId);
+                    String newToken = jwt.generateToken();
                     playerService.reconnectFromPreviousSession(oldSessionId, sessionId,
                             newToken);
                     // TODO: actualizar la room si existe donde estuviera el anterior jugador
@@ -88,7 +88,7 @@ public class GameSessionController {
             }
         }
 
-        String newToken = jwt.generateToken(sessionId);
+        String newToken = jwt.generateToken();
         playerService.addToken(sessionId, newToken);
         return new TokenIdResponseDto(newToken);
     }

--- a/griffindor-backend/src/main/java/com/devathon/griffindor_backend/middleware/CustomHandshakeMiddleware.java
+++ b/griffindor-backend/src/main/java/com/devathon/griffindor_backend/middleware/CustomHandshakeMiddleware.java
@@ -6,36 +6,68 @@ import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.server.HandshakeInterceptor;
 
+import com.devathon.griffindor_backend.utils.Jwt;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import jakarta.servlet.http.Cookie;
+
+import javax.crypto.SecretKey;
 
 public class CustomHandshakeMiddleware implements HandshakeInterceptor {
 
     @Override
-    public boolean beforeHandshake(
-            ServerHttpRequest request,
-            ServerHttpResponse response,
-            WebSocketHandler wsHandler,
-            Map<String, Object> attributes) throws Exception {
+public boolean beforeHandshake(
+        ServerHttpRequest request,
+        ServerHttpResponse response,
+        WebSocketHandler wsHandler,
+        Map<String, Object> attributes) throws Exception {
 
         if (request instanceof ServletServerHttpRequest servletRequest) {
-            var params = servletRequest.getServletRequest().getParameterMap();
-            String[] tokensIds = params.get("token_id");
+            Cookie[] cookies = servletRequest.getServletRequest().getCookies();
+            String token = null;
 
-            if (tokensIds != null && tokensIds.length == 1) {
-                String token = tokensIds[0];
-                attributes.put("token_id", token);
+            if (cookies != null) {
+                for (Cookie cookie : cookies) {
+                    if ("token_id".equals(cookie.getName())) {
+                        token = cookie.getValue();
+                        break;
+                    }
+                }
+            }
+            
+            if (token != null) {
+                try {
+                    SecretKey secretKey = Keys.hmacShaKeyFor(System.getenv("JWT_SECRET").getBytes(StandardCharsets.UTF_8));
+                    Jwts.parserBuilder()
+                            .setSigningKey(secretKey)
+                            .build()
+                            .parseClaimsJws(token)
+                            .getBody();
+                    attributes.put("token_id", token);
+                } catch (Exception e) {
+                    
+                    return false;
+                }
+            } else {
+                String newToken = new Jwt().generateToken();
+                attributes.put("token_id", newToken);
+                response.getHeaders().add("Set-Cookie", "token_id=" + newToken + "; Path=/; HttpOnly");
             }
         }
-
         return true;
     }
 
     @Override
     public void afterHandshake(
-            ServerHttpRequest request,
-            ServerHttpResponse response,
-            WebSocketHandler wsHandler,
-            Exception exception) {
+          ServerHttpRequest request,
+          ServerHttpResponse response,
+          WebSocketHandler wsHandler,
+          Exception exception) {
         // No-op
     }
+
 }

--- a/griffindor-backend/src/main/java/com/devathon/griffindor_backend/utils/Jwt.java
+++ b/griffindor-backend/src/main/java/com/devathon/griffindor_backend/utils/Jwt.java
@@ -4,9 +4,12 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Date;
 import java.util.Map;
+
+import javax.crypto.SecretKey;
 
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.GenericMessage;
@@ -17,12 +20,24 @@ public class Jwt {
 
     private final Key secretKey = Keys.secretKeyFor(SignatureAlgorithm.HS256);
 
-    public String generateToken(String sessionId) {
+    
+    
+
+    public String generateToken() { 
+        
+        
+
+        if (System.getenv("JWT_SECRET") == null) {
+            throw new IllegalArgumentException("JWT_SECRET cannot be null");
+        }
+    
+        SecretKey secretKey = Keys.hmacShaKeyFor(System.getenv("JWT_SECRET").getBytes(StandardCharsets.UTF_8));
+
         long nowMillis = System.currentTimeMillis();
         long expMillis = nowMillis + 1000 * 60 * 60;
 
         return Jwts.builder()
-                .setSubject(sessionId)
+                .setSubject("user_" + nowMillis)
                 .setIssuedAt(new Date(nowMillis))
                 .setExpiration(new Date(expMillis))
                 .signWith(secretKey)


### PR DESCRIPTION
The jwt_secret environment variable is created for the implementation when generating the token.

The cookie check and verification of the token's existence are added to the header.

If none exist, a token is generated and sent to the client.

If it exists, it is added to the attributes.

This implementation is transparent to the frontend since the token cannot be accessed via JavaScript; the browser is responsible for adding it to the headers.

The backend can now identify players with the token_id attribute.