### PR TITLE
Chore/doc endpoints refactors

### DIFF
--- a/griffindor-backend/.env.example
+++ b/griffindor-backend/.env.example
@@ -10,3 +10,5 @@ DB_PASS=                  # Contraseña para el usuario de la base de datos dent
 DB_HOST=                  # Dirección del host donde se encuentra la base de datos (por lo general, el nombre del servicio de Docker o localhost)
 DB_PORT=                  # Puerto de la base de datos (por lo general, el puerto 3306 para MySQL)
 DB_ROOT_PASSWORD=         # Contraseña para el usuario root de la base de datos dentro del contenedor Docker
+
+JWT_SECRET=               # Clave secreta para JWT

--- a/griffindor-backend/src/main/java/com/devathon/griffindor_backend/config/WebSocketRoutes.java
+++ b/griffindor-backend/src/main/java/com/devathon/griffindor_backend/config/WebSocketRoutes.java
@@ -41,5 +41,6 @@ public class WebSocketRoutes {
 
     // Queue Paths Subscriber
     public static final String USER_QUEUE_LIST_PLAYERS = USER_PREFIX + QUEUE_PREFIX + LIST_PLAYERS;
+    public static final String USER_QUEUE_DUEL = USER_PREFIX + QUEUE_PREFIX + DUEL;
 
 }

--- a/griffindor-backend/src/main/java/com/devathon/griffindor_backend/controllers/AssignRoomController.java
+++ b/griffindor-backend/src/main/java/com/devathon/griffindor_backend/controllers/AssignRoomController.java
@@ -2,6 +2,7 @@ package com.devathon.griffindor_backend.controllers;
 
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.simp.annotation.SendToUser;
 import org.springframework.stereotype.Controller;
 import com.devathon.griffindor_backend.Queues.RoomReadyQueue;
 import com.devathon.griffindor_backend.Queues.WaitlistQueue;
@@ -26,6 +27,7 @@ public class AssignRoomController {
     private final RoomReadyQueue roomReadyQueue;
 
     @MessageMapping(WebSocketRoutes.DUEL)
+    @SendToUser(WebSocketRoutes.USER_QUEUE_DUEL)
     public void assignRoom(SimpMessageHeaderAccessor headerAccessor) {
 
         String sessionId = headerAccessor.getSessionId();

--- a/griffindor-backend/src/main/java/com/devathon/griffindor_backend/controllers/GameSessionController.java
+++ b/griffindor-backend/src/main/java/com/devathon/griffindor_backend/controllers/GameSessionController.java
@@ -67,7 +67,7 @@ public class GameSessionController {
                 String oldSessionId = jwt.validateAndGetUser(token);
 
                 if (playerService.existsBySessionId(oldSessionId)) {
-                    String newToken = jwt.generateToken(sessionId);
+                    String newToken = jwt.generateToken();
                     playerService.reconnectFromPreviousSession(oldSessionId, sessionId,
                             newToken);
                     // TODO: actualizar la room si existe donde estuviera el anterior jugador
@@ -88,7 +88,7 @@ public class GameSessionController {
             }
         }
 
-        String newToken = jwt.generateToken(sessionId);
+        String newToken = jwt.generateToken();
         playerService.addToken(sessionId, newToken);
         return new TokenIdResponseDto(newToken);
     }

--- a/griffindor-backend/src/main/java/com/devathon/griffindor_backend/controllers/GameSessionController.java
+++ b/griffindor-backend/src/main/java/com/devathon/griffindor_backend/controllers/GameSessionController.java
@@ -2,22 +2,16 @@ package com.devathon.griffindor_backend.controllers;
 
 import com.devathon.griffindor_backend.config.WebSocketRoutes;
 import com.devathon.griffindor_backend.dtos.TokenIdResponseDto;
-import com.devathon.griffindor_backend.enums.PlayerSessionState;
 import com.devathon.griffindor_backend.services.ErrorService;
 import com.devathon.griffindor_backend.services.PlayerService;
 import com.devathon.griffindor_backend.utils.Jwt;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.event.EventListener;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.annotation.SendToUser;
-import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.socket.messaging.SessionConnectedEvent;
-import org.springframework.web.socket.messaging.SessionDisconnectEvent;
-import org.springframework.web.socket.messaging.SessionSubscribeEvent;
 
 @RequiredArgsConstructor
 @Controller
@@ -28,33 +22,7 @@ public class GameSessionController {
     private final Jwt jwt;
     private final ErrorService errorService;
 
-    @EventListener
-    public void handleWebSocketConnectListener(SessionConnectedEvent event) {
-        String sessionId = getSessionIdFromEvent(event);
-        playerService.addPlayer(sessionId, null, null, PlayerSessionState.CONNECT, null);
-    }
-
-    @EventListener
-    public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
-        String sessionId = getSessionIdFromEvent(event);
-        playerService.updatePlayerSessionState(sessionId, PlayerSessionState.DISCONNECT);
-    }
-
-    @EventListener
-    public void handleSubscribeEvent(SessionSubscribeEvent event) {
-        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
-
-        String sessionId = headerAccessor.getSessionId();
-        String destination = headerAccessor.getDestination();
-
-        if (WebSocketRoutes.TOPIC_NUM_PLAYERS.equals(destination)) {
-            playerService.enqueuePlayersConnectedEvent(sessionId);
-
-        }
-        if (WebSocketRoutes.USER_QUEUE_LIST_PLAYERS.equals(destination)) {
-            playerService.enqueuePlayersListEvent(sessionId);
-        }
-    }
+   
 
     @MessageMapping(WebSocketRoutes.TOKEN_ID)
     @SendToUser(WebSocketRoutes.QUEUE_TOKEN_ID)
@@ -93,11 +61,5 @@ public class GameSessionController {
         return new TokenIdResponseDto(newToken);
     }
 
-    private String getSessionIdFromEvent(SessionConnectedEvent event) {
-        return StompHeaderAccessor.wrap(event.getMessage()).getSessionId();
-    }
 
-    private String getSessionIdFromEvent(SessionDisconnectEvent event) {
-        return StompHeaderAccessor.wrap(event.getMessage()).getSessionId();
-    }
 }

--- a/griffindor-backend/src/main/java/com/devathon/griffindor_backend/controllers/PlayersOnlineController.java
+++ b/griffindor-backend/src/main/java/com/devathon/griffindor_backend/controllers/PlayersOnlineController.java
@@ -11,6 +11,10 @@ import com.devathon.griffindor_backend.dtos.PlayerRegisterDto;
 import com.devathon.griffindor_backend.models.Player;
 import com.devathon.griffindor_backend.services.ErrorService;
 import com.devathon.griffindor_backend.services.PlayerService;
+
+import io.github.springwolf.core.asyncapi.annotations.AsyncMessage;
+import io.github.springwolf.core.asyncapi.annotations.AsyncOperation;
+import io.github.springwolf.core.asyncapi.annotations.AsyncPublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -24,6 +28,16 @@ public class PlayersOnlineController {
 
     @MessageMapping(WebSocketRoutes.REGISTER_USER)
     @SendToUser(WebSocketRoutes.QUEUE_REGISTER_USER)
+    @AsyncPublisher(operation = @AsyncOperation(
+            channelName = WebSocketRoutes.QUEUE_REGISTER_USER,
+            description = "Notify the player about the registration result.",
+            payloadType = PlayerDto.class,
+            message = @AsyncMessage(
+                    messageId = "player-registration-id",
+                    name = "PlayerDto",
+                    description = "Payload model for player registration response."
+            )
+    ))
     public PlayerDto registerPlayer(@Payload PlayerRegisterDto playerRegisterDto,
             SimpMessageHeaderAccessor headerAccessor) {
 

--- a/griffindor-backend/src/main/java/com/devathon/griffindor_backend/listeners/RoomReadyListener.java
+++ b/griffindor-backend/src/main/java/com/devathon/griffindor_backend/listeners/RoomReadyListener.java
@@ -1,13 +1,25 @@
 package com.devathon.griffindor_backend.listeners;
 
 import com.devathon.griffindor_backend.Queues.RoomReadyQueue;
+import com.devathon.griffindor_backend.config.WebSocketRoutes;
+import com.devathon.griffindor_backend.dtos.RoomIdResponseDto;
 import com.devathon.griffindor_backend.events.RoomReadyEvent;
+
+import io.github.springwolf.core.asyncapi.annotations.AsyncMessage;
+import io.github.springwolf.core.asyncapi.annotations.AsyncOperation;
+import io.github.springwolf.core.asyncapi.annotations.AsyncPublisher;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+
+import java.net.http.WebSocket;
+
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+
 
 @Component
 @RequiredArgsConstructor
@@ -16,7 +28,24 @@ public class RoomReadyListener {
     private final SimpMessagingTemplate messagingTemplate;
     private final RoomReadyQueue roomReadyQueue;
 
+    private MessageHeaders buildHeaders(String sessionId) {
+        SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.create();
+        accessor.setSessionId(sessionId);
+        accessor.setLeaveMutable(true);
+        return accessor.getMessageHeaders();
+    }
+
     @Scheduled(fixedRate = 500)
+    @AsyncPublisher(operation = @AsyncOperation(
+            channelName = WebSocketRoutes.USER_QUEUE_DUEL,
+            description = "Notify players when the room is ready",
+            payloadType = RoomIdResponseDto.class,
+            message = @AsyncMessage(
+                    messageId = "room-ready-id",
+                    name = "RoomIdResponseDto",
+                    description = "Payload model for room ready event, including room_id"
+            )
+    ))
     public void processQueue() {
         RoomReadyEvent event;
         while ((event = roomReadyQueue.poll()) != null) {
@@ -30,10 +59,5 @@ public class RoomReadyListener {
         }
     }
 
-    private MessageHeaders buildHeaders(String sessionId) {
-        SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.create();
-        accessor.setSessionId(sessionId);
-        accessor.setLeaveMutable(true);
-        return accessor.getMessageHeaders();
-    }
+    
 }

--- a/griffindor-backend/src/main/java/com/devathon/griffindor_backend/listeners/SessionConnectedListener.java
+++ b/griffindor-backend/src/main/java/com/devathon/griffindor_backend/listeners/SessionConnectedListener.java
@@ -1,0 +1,58 @@
+package com.devathon.griffindor_backend.listeners;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectedEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+
+import com.devathon.griffindor_backend.config.WebSocketRoutes;
+import com.devathon.griffindor_backend.enums.PlayerSessionState;
+import com.devathon.griffindor_backend.services.PlayerService;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SessionConnectedListener {
+
+  private final PlayerService playerService;
+
+  @EventListener
+    public void handleWebSocketConnectListener(SessionConnectedEvent event) {
+        String sessionId = getSessionIdFromEvent(event);
+        playerService.addPlayer(sessionId, null, null, PlayerSessionState.CONNECT, null);
+    }
+
+    @EventListener
+    public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
+        String sessionId = getSessionIdFromEvent(event);
+        playerService.updatePlayerSessionState(sessionId, PlayerSessionState.DISCONNECT);
+    }
+
+    @EventListener
+    public void handleSubscribeEvent(SessionSubscribeEvent event) {
+        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+
+        String sessionId = headerAccessor.getSessionId();
+        String destination = headerAccessor.getDestination();
+
+        if (WebSocketRoutes.TOPIC_NUM_PLAYERS.equals(destination)) {
+            playerService.enqueuePlayersConnectedEvent(sessionId);
+
+        }
+        if (WebSocketRoutes.USER_QUEUE_LIST_PLAYERS.equals(destination)) {
+            playerService.enqueuePlayersListEvent(sessionId);
+        }
+    }
+
+  private String getSessionIdFromEvent(SessionConnectedEvent event) {
+    return StompHeaderAccessor.wrap(event.getMessage()).getSessionId();
+  }
+
+  private String getSessionIdFromEvent(SessionDisconnectEvent event) {
+    return StompHeaderAccessor.wrap(event.getMessage()).getSessionId();
+  }
+
+}

--- a/griffindor-backend/src/main/java/com/devathon/griffindor_backend/middleware/CustomHandshakeMiddleware.java
+++ b/griffindor-backend/src/main/java/com/devathon/griffindor_backend/middleware/CustomHandshakeMiddleware.java
@@ -6,36 +6,68 @@ import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.server.HandshakeInterceptor;
 
+import com.devathon.griffindor_backend.utils.Jwt;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import jakarta.servlet.http.Cookie;
+
+import javax.crypto.SecretKey;
 
 public class CustomHandshakeMiddleware implements HandshakeInterceptor {
 
     @Override
-    public boolean beforeHandshake(
-            ServerHttpRequest request,
-            ServerHttpResponse response,
-            WebSocketHandler wsHandler,
-            Map<String, Object> attributes) throws Exception {
+public boolean beforeHandshake(
+        ServerHttpRequest request,
+        ServerHttpResponse response,
+        WebSocketHandler wsHandler,
+        Map<String, Object> attributes) throws Exception {
 
         if (request instanceof ServletServerHttpRequest servletRequest) {
-            var params = servletRequest.getServletRequest().getParameterMap();
-            String[] tokensIds = params.get("token_id");
+            Cookie[] cookies = servletRequest.getServletRequest().getCookies();
+            String token = null;
 
-            if (tokensIds != null && tokensIds.length == 1) {
-                String token = tokensIds[0];
-                attributes.put("token_id", token);
+            if (cookies != null) {
+                for (Cookie cookie : cookies) {
+                    if ("token_id".equals(cookie.getName())) {
+                        token = cookie.getValue();
+                        break;
+                    }
+                }
+            }
+            
+            if (token != null) {
+                try {
+                    SecretKey secretKey = Keys.hmacShaKeyFor(System.getenv("JWT_SECRET").getBytes(StandardCharsets.UTF_8));
+                    Jwts.parserBuilder()
+                            .setSigningKey(secretKey)
+                            .build()
+                            .parseClaimsJws(token)
+                            .getBody();
+                    attributes.put("token_id", token);
+                } catch (Exception e) {
+                    
+                    return false;
+                }
+            } else {
+                String newToken = new Jwt().generateToken();
+                attributes.put("token_id", newToken);
+                response.getHeaders().add("Set-Cookie", "token_id=" + newToken + "; Path=/; HttpOnly");
             }
         }
-
         return true;
     }
 
     @Override
     public void afterHandshake(
-            ServerHttpRequest request,
-            ServerHttpResponse response,
-            WebSocketHandler wsHandler,
-            Exception exception) {
+          ServerHttpRequest request,
+          ServerHttpResponse response,
+          WebSocketHandler wsHandler,
+          Exception exception) {
         // No-op
     }
+
 }

--- a/griffindor-backend/src/main/java/com/devathon/griffindor_backend/utils/Jwt.java
+++ b/griffindor-backend/src/main/java/com/devathon/griffindor_backend/utils/Jwt.java
@@ -4,9 +4,12 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Date;
 import java.util.Map;
+
+import javax.crypto.SecretKey;
 
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.GenericMessage;
@@ -17,12 +20,24 @@ public class Jwt {
 
     private final Key secretKey = Keys.secretKeyFor(SignatureAlgorithm.HS256);
 
-    public String generateToken(String sessionId) {
+    
+    
+
+    public String generateToken() { 
+        
+        
+
+        if (System.getenv("JWT_SECRET") == null) {
+            throw new IllegalArgumentException("JWT_SECRET cannot be null");
+        }
+    
+        SecretKey secretKey = Keys.hmacShaKeyFor(System.getenv("JWT_SECRET").getBytes(StandardCharsets.UTF_8));
+
         long nowMillis = System.currentTimeMillis();
         long expMillis = nowMillis + 1000 * 60 * 60;
 
         return Jwts.builder()
-                .setSubject(sessionId)
+                .setSubject("user_" + nowMillis)
                 .setIssuedAt(new Date(nowMillis))
                 .setExpiration(new Date(expMillis))
                 .signWith(secretKey)


### PR DESCRIPTION
Springwolf documentation has been expanded.
Documentation path: http://localhost:8080/springwolf/asyncapi-ui.html

AssignRoomController has been refactored. It had some listeners, which have been moved to the listener folder, and RoomReadyListener has been created to contain them.

The @AsyncPublisher and @AsyncOperation.Headers annotations have been added to each controller to expand the information on the controllers and response queues.

example :
![image](https://github.com/user-attachments/assets/3425d676-0922-4aeb-bd56-bce5a9a576e2)
It now contains the response path, which is a button with a link to expand the explanation of the path

and is sent as a response.

Queues
![image](https://github.com/user-attachments/assets/94a5a23f-9ea4-406f-96e6-43adb5d91bda)
Now the queues contain a brief description and what responses they send to the user.

Remember that if annotations are used correctly, Springwolf automatically generates documentation so the entire team is aware of changes, since it's based on OpenAPI, like other REST-based solutions like Swagger.

See you next time.