### PR TITLE
feat(SpellServiceImpl): add logic to resolve rounds when one or both …

### DIFF
--- a/griffindor-backend/src/main/java/com/devathon/griffindor_backend/controllers/DuelController.java
+++ b/griffindor-backend/src/main/java/com/devathon/griffindor_backend/controllers/DuelController.java
@@ -57,7 +57,7 @@ public class DuelController {
             return;
         }
 
-        if (!spellService.spellExist(roundRequest.spellId())) {
+        if (roundRequest.spellId() != null && !spellService.spellExist(roundRequest.spellId())) {
             errorService.sendErrorToSession(sessionId, "SPELL_NOT_FOUND", "Spell not found");
             return;
         }

--- a/griffindor-backend/src/main/java/com/devathon/griffindor_backend/services/Impl/SpellServiceImpl.java
+++ b/griffindor-backend/src/main/java/com/devathon/griffindor_backend/services/Impl/SpellServiceImpl.java
@@ -35,6 +35,23 @@ public class SpellServiceImpl implements SpellService {
         UUID spell1Id = room.getPlayers().get(player1Id).getSpellForRound(round);
         UUID spell2Id = room.getPlayers().get(player2Id).getSpellForRound(round);
 
+        // If both spells are null, it's a draw
+        if (spell1Id == null && spell2Id == null) {
+            return new RoundResult(null, RoundStatus.DRAW);
+        }
+
+        // If one spell is null, that player loses
+        if (spell1Id == null) {
+            room.getPlayers().get(player2Id).incrementRoundsWon();
+            return new RoundResult(player2Id, RoundStatus.WINNER);
+        }
+
+        if (spell2Id == null) {
+            room.getPlayers().get(player1Id).incrementRoundsWon();
+            return new RoundResult(player1Id, RoundStatus.WINNER);
+        }
+
+        // If both spells are the same, it's a draw
         if (spell1Id.equals(spell2Id)) {
             return new RoundResult(null, RoundStatus.DRAW);
         }


### PR DESCRIPTION
…players cast no spell

Se agrega lógica para manejar hechizo nulos durante una ronda.
 
- Si ambos jugadores no lanzan hechizo, el resultado de la ronda es empate.
- Si uno solo de los jugadores no lanza hechizo, pierde automáticamente la ronda.
- Si ambos lanzan hechizos válidos, se mantiene la lógica de comparación existente. 