### PR TITLE
fix(DuelController): add synchronized block on room to prevent race c…

### DIFF
--- a/griffindor-backend/src/main/java/com/devathon/griffindor_backend/controllers/DuelController.java
+++ b/griffindor-backend/src/main/java/com/devathon/griffindor_backend/controllers/DuelController.java
@@ -127,6 +127,7 @@ public class DuelController {
                     room.getPlayerIds()
                             .forEach(playerId -> playerService.updatePlayerSessionState(playerId, PlayerSessionState.CONNECT));
                     roomService.deleteRoom(roomId);
+                    return;
                 }
 
                 // Advance to the next round


### PR DESCRIPTION
…onditions during round submission

Se agrega **synchronized** al método `handleRound` en `DuelController` utilizando la instancia de `room` para evitar condiciones de carrera cuando ambos jugadores envían su hechizo al mismo tiempo en una misma ronda. 

Se utiliza la instancia de `room` para bloquear solo entre hilos que trabajan sobre la misma sala y evitar condiciones de carrera al modificar el estado de la sala, permitiendo la concurrencia entre salas distintas.